### PR TITLE
Don't disallow special tokens

### DIFF
--- a/history.py
+++ b/history.py
@@ -79,7 +79,7 @@ class Message(BaseModel):
             encoding = tiktoken.encoding_for_model(self.model_str)
         except KeyError:
             encoding = tiktoken.encoding_for_model(DEFAULT_MODEL_SLUG)
-        return len(encoding.encode(self.text))
+        return len(encoding.encode(self.text, disallowed_special=()))
 
 
 class MessageMapping(BaseModel):


### PR DESCRIPTION
This fixes a tiktoken-related error:

```
ValueError: Encountered text corresponding to disallowed special token '<|endoftext|>'.
If you want this text to be encoded as a special token, pass it to `allowed_special`, e.g. `allowed_special={'<|endoftext|>', ...}`.
If you want this text to be encoded as normal text, disable the check for this token by passing `disallowed_special=(enc.special_tokens_set - {'<|endoftext|>'})`.
To disable this check for all special tokens, pass `disallowed_special=()`.
```